### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   check:
     name: Check
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/USED255/Annotations2Sub/security/code-scanning/2](https://github.com/USED255/Annotations2Sub/security/code-scanning/2)

The best way to fix the problem is to add an explicit `permissions` block setting minimal necessary privileges (in this case, `contents: read`) to the job or at the workflow root. Since the error was flagged on the `check` job (`jobs.check`), it's most appropriate and least intrusive to add the `permissions` block directly to that job, just above `runs-on`. This will ensure that the job does not inherit unnecessarily broad permissions from repository defaults. No additional imports, methods, or changes to the code logic are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
