### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -19,6 +19,8 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/USED255/Annotations2Sub/security/code-scanning/1](https://github.com/USED255/Annotations2Sub/security/code-scanning/1)

To fix the problem, explicitly declare the `permissions` block at the job level for the `build` job, which is flagged by the analysis. The block should assign only the minimal permissions needed—in this case, `contents: read` is sufficient since the job only reads repository contents to perform the build and does not perform any write actions to the repository, or interact with issues or pull requests. No other steps or permissions are needed. Edit the `.github/workflows/test-build.yml` file, and after the `runs-on: ubuntu-latest` line (line 21), add a `permissions` block specifying `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
